### PR TITLE
Drop "`", "," and "." from links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,16 @@ In short the features of `markdown-toc` are:
 # Table of Contents
 
 - [markdown-toc](#markdown-toc)
+- [Table of Contents](#table-of-contents)
 - [Example usage](#example-usage)
-  - [Generating a ToC to `stdout`](#generating-a-toc-to-`stdout`)
+  - [Generating a ToC to `stdout`](#generating-a-toc-to-stdout)
   - [Set a custom header](#set-a-custom-header)
-  - [Print the full Markdown file, not only the ToC](#print-the-full-markdown-file,-not-only-the-toc)
+  - [Print the full Markdown file, not only the ToC](#print-the-full-markdown-file-not-only-the-toc)
   - [Inject the ToC into a file on disk](#inject-the-toc-into-a-file-on-disk)
 - [Helping out!](#helping-out!)
 - [License](#license)
 <!-- ToC end -->
+
 
 
 # Example usage

--- a/toc/slugify.go
+++ b/toc/slugify.go
@@ -6,7 +6,11 @@ import "strings"
 // rules here are adapted to how GitHub is creating slugs from the headers.
 func slugify(s string) string {
 	droppedChars := []string{
-		"\"", "'",
+		"\"",
+		"'",
+		"`",
+		".",
+		",",
 		"(", ")",
 		"{", "}",
 		"[", "]",

--- a/toc/slugify_test.go
+++ b/toc/slugify_test.go
@@ -11,13 +11,16 @@ func TestSlugify(t *testing.T) {
 		in       string
 		expected string
 	}{
-		"applies lower case":    {in: "MysTrInghEre", expected: "mystringhere"},
-		"replace space with -":  {in: "Some ex ample", expected: "some-ex-ample"},
-		"replace () with space": {in: "Header (something)", expected: "header-something"},
-		"replace [] with space": {in: "Header [something]", expected: "header-something"},
-		"replace {} with space": {in: "Header {something}", expected: "header-something"},
-		"replace \" with space": {in: "Header \"something\"", expected: "header-something"},
-		"replace ' with space":  {in: "Header 'something'", expected: "header-something"},
+		"applies lower case":   {in: "MysTrInghEre", expected: "mystringhere"},
+		"replace space with -": {in: "Some ex ample", expected: "some-ex-ample"},
+		"drop ()":              {in: "Header (something)", expected: "header-something"},
+		"drop []":              {in: "Header [something]", expected: "header-something"},
+		"drop {}":              {in: "Header {something}", expected: "header-something"},
+		"drop \"":              {in: "Header \"something\"", expected: "header-something"},
+		"drop '":               {in: "Header 'something'", expected: "header-something"},
+		"drop `":               {in: "Header `something`", expected: "header-something"},
+		"drop .":               {in: "Header .something.", expected: "header-something"},
+		"drop ,":               {in: "Header ,something,", expected: "header-something"},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
Drop "`", "," and "." from links.

Closes #9
Closes #10