### PR TITLE
Don't add extra newlines after the ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ In short the features of `markdown-toc` are:
 - [License](#license)
 <!-- ToC end -->
 
-
-
-
 # Example usage
 
 ## Generating a ToC to `stdout`

--- a/toc/build.go
+++ b/toc/build.go
@@ -48,7 +48,7 @@ func Build(d []byte, header string, addHeader bool) ([]string, error) {
 		return []string{}, err
 	}
 
-	toc = append(toc, "<!-- ToC end -->\n")
+	toc = append(toc, "<!-- ToC end -->")
 
 	return toc, nil
 }

--- a/toc/build_test.go
+++ b/toc/build_test.go
@@ -20,7 +20,7 @@ func TestBuild(t *testing.T) {
 			expectedToC: []string{
 				"<!-- ToC start -->",
 				"# Table of Contents\n",
-				"<!-- ToC end -->\n",
+				"<!-- ToC end -->",
 			},
 		},
 		"success - full example": {
@@ -62,7 +62,7 @@ Some content
 				"  - [Header 4](#header-4)",
 				"    - [Header 5](#header-5)",
 				"      - [Header 6](#header-6)",
-				"<!-- ToC end -->\n",
+				"<!-- ToC end -->",
 			},
 		},
 	}


### PR DESCRIPTION
If you ran markdown-toc many times you'd end up with a good number of
newlines after the ToC.