### PR TITLE
Skip headers flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ Output:
     - [License](#license)
     <!-- ToC end -->
 
+## Skip `n` headers
+
+If you do not want to include `n` number of initial headers in your ToC, you can
+use the `--skip-headers=1` flag. This is useful if you have your project name as
+the first header and you don't really want that in the ToC for example.
+
+Command:
+
+    markdown-toc --skip-headers=1 README.md
+
+Output:
+
+    <!-- ToC start -->
+    - [Example usage](#example-usage)
+      - [Generating a ToC to `stdout`](#generating-a-toc-to-`stdout`)
+    - [License](#license)
+    <!-- ToC end -->
+
 ## Print the full Markdown file, not only the ToC
 
     markdown-toc --replace README.md

--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ Output:
     - [License](#license)
     <!-- ToC end -->
 
+## Render the ToC without a header
+
+Command:
+
+    markdown-toc --no-header README.md
+
+Output:
+
+    <!-- ToC start -->
+    - [`markdown-toc` - Generate your Table of Contents](#`markdown-toc`---generate-your-table-of-contents)
+    - [Example usage](#example-usage)
+      - [Generating a ToC to `stdout`](#generating-a-toc-to-`stdout`)
+    - [License](#license)
+    <!-- ToC end -->
+
 ## Print the full Markdown file, not only the ToC
 
     markdown-toc --replace README.md

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,9 +14,9 @@ var (
 	// header is the string injected as a header for the table of contents.
 	header string
 
-	// skipHeader is indicating whether or not a header should be injected in
-	// the table of contents.
-	skipHeader bool
+	// noHeader is indicating whether or not a header should be injected in the
+	// table of contents.
+	noHeader bool
 
 	// replaceToC is indicating whether we should replace the table of contents
 	// in the input file. This assumes that there are two tags indicating where
@@ -44,7 +44,7 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
-		t, err := toc.Build(d, header, !skipHeader)
+		t, err := toc.Build(d, header, !noHeader)
 		if err != nil {
 			return err
 		}
@@ -78,7 +78,7 @@ var RootCmd = &cobra.Command{
 
 func init() {
 	RootCmd.Flags().StringVar(&header, "header", "# Table of Contents", "Text to use for the header for the ToC")
-	RootCmd.Flags().BoolVar(&skipHeader, "skip-header", false, "If this is set there will be no header for the ToC")
+	RootCmd.Flags().BoolVar(&noHeader, "no-header", false, "If this is set there will be no header for the ToC")
 	RootCmd.Flags().BoolVar(&replaceToC, "replace", false, "If the replace flag is set the full markdown will be returned and any existing ToC replaced")
 	RootCmd.Flags().BoolVar(&inline, "inline", false, "Overwrite the input file with the output from this command. Should be used together with --replace")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,9 +14,22 @@ var (
 	// header is the string injected as a header for the table of contents.
 	header string
 
+	// inline indicates whether we should do an inline replacement of the ToC or
+	// if we should print to stdout. Default is to print to stdout.
+	inline bool
+
 	// noHeader is indicating whether or not a header should be injected in the
 	// table of contents.
 	noHeader bool
+
+	// skipHeaders is indicating how many of headers we should skip from the
+	// top. This is useful for projects that has e.g. the project name as the
+	// first header, but they don't want that to go in the ToC.
+	//
+	// The flag is ignoring the header size (H1, H2, etc).
+	//
+	// If this is set to 0 no headers would be skipped.
+	skipHeaders = 0
 
 	// replaceToC is indicating whether we should replace the table of contents
 	// in the input file. This assumes that there are two tags indicating where
@@ -28,10 +41,6 @@ var (
 	// If these tags are not found, the table of contents will be injected on
 	// top all existing content in the markdown file.
 	replaceToC bool
-
-	// inline indicates whether we should do an inline replacement of the ToC or
-	// if we should print to stdout. Default is to print to stdout.
-	inline bool
 )
 
 var RootCmd = &cobra.Command{
@@ -44,7 +53,7 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
-		t, err := toc.Build(d, header, !noHeader)
+		t, err := toc.Build(d, header, skipHeaders, !noHeader)
 		if err != nil {
 			return err
 		}
@@ -79,6 +88,7 @@ var RootCmd = &cobra.Command{
 func init() {
 	RootCmd.Flags().StringVar(&header, "header", "# Table of Contents", "Text to use for the header for the ToC")
 	RootCmd.Flags().BoolVar(&noHeader, "no-header", false, "If this is set there will be no header for the ToC")
+	RootCmd.Flags().IntVar(&skipHeaders, "skip-headers", 0, "Number of headers to skip. Useful if you don't want e.g. the first header to be included in the ToC")
 	RootCmd.Flags().BoolVar(&replaceToC, "replace", false, "If the replace flag is set the full markdown will be returned and any existing ToC replaced")
 	RootCmd.Flags().BoolVar(&inline, "inline", false, "Overwrite the input file with the output from this command. Should be used together with --replace")
 }

--- a/toc/build.go
+++ b/toc/build.go
@@ -15,7 +15,7 @@ var (
 )
 
 // Build is returning a ToC based on the input markdown.
-func Build(d []byte, header string, addHeader bool) ([]string, error) {
+func Build(d []byte, header string, skipHeaders int, addHeader bool) ([]string, error) {
 	toc := []string{
 		"<!-- ToC start -->",
 	}
@@ -33,12 +33,27 @@ func Build(d []byte, header string, addHeader bool) ([]string, error) {
 			indent := len(m[1]) - 1
 			title := m[2]
 
+			if skipHeaders > 0 {
+				skipHeaders--
+				continue
+			}
+
 			toc = append(toc, fmt.Sprintf("%s- [%s](#%s)", strings.Repeat("  ", indent), title, slugify(title)))
 
 		case rUnderscoreHeader1.Match(s.Bytes()):
+			if skipHeaders > 0 {
+				skipHeaders--
+				continue
+			}
+
 			toc = append(toc, fmt.Sprintf("- [%s](#%s)", previousLine, slugify(previousLine)))
 
 		case rUnderscoreHeader2.Match(s.Bytes()):
+			if skipHeaders > 0 {
+				skipHeaders--
+				continue
+			}
+
 			toc = append(toc, fmt.Sprintf("  - [%s](#%s)", previousLine, slugify(previousLine)))
 		}
 

--- a/toc/build_test.go
+++ b/toc/build_test.go
@@ -10,13 +10,15 @@ func TestBuild(t *testing.T) {
 	testCases := map[string]struct {
 		data        []byte
 		header      string
+		skipHeaders int
 		addHeader   bool
 		expectedToC []string
 	}{
 		"success - empty markdown": {
-			data:      []byte(``),
-			header:    "# Table of Contents",
-			addHeader: true,
+			data:        []byte(``),
+			header:      "# Table of Contents",
+			skipHeaders: 0,
+			addHeader:   true,
 			expectedToC: []string{
 				"<!-- ToC start -->",
 				"# Table of Contents\n",
@@ -51,8 +53,9 @@ Some content
 
 Some content
 `),
-			header:    "# Table of Contents",
-			addHeader: true,
+			header:      "# Table of Contents",
+			skipHeaders: 0,
+			addHeader:   true,
 			expectedToC: []string{
 				"<!-- ToC start -->",
 				"# Table of Contents\n",
@@ -65,11 +68,51 @@ Some content
 				"<!-- ToC end -->",
 			},
 		},
+		"skipping 3 headers": {
+			data: []byte(`
+Header 1
+========
+
+Some content
+
+Header 2
+--------
+
+Some content
+
+# Header 3
+
+Some content
+
+## Header 4
+
+Some content
+
+### Header 5
+
+Some content
+
+#### Header 6
+
+Some content
+`),
+			header:      "# Table of Contents",
+			skipHeaders: 3,
+			addHeader:   true,
+			expectedToC: []string{
+				"<!-- ToC start -->",
+				"# Table of Contents\n",
+				"  - [Header 4](#header-4)",
+				"    - [Header 5](#header-5)",
+				"      - [Header 6](#header-6)",
+				"<!-- ToC end -->",
+			},
+		},
 	}
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			toc, err := Build(testCase.data, testCase.header, testCase.addHeader)
+			toc, err := Build(testCase.data, testCase.header, testCase.skipHeaders, testCase.addHeader)
 			assert.Nil(t, err)
 			assert.Equal(t, testCase.expectedToC, toc)
 		})


### PR DESCRIPTION
This PR is introducing a `--skip-headers=1` flag which is described in #14. We
are also renaming `--skip-header` to `--no-header` to make the flags purposes
more clear.