### PR TITLE
Add --depth flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ In short the features of `markdown-toc` are:
 - Cross platform (OS X, Linux, Windows)
 - Replacement of an existing ToC
   - The new file can be written to `stdout` or overwritten on disk
-- Configurable header
+- Able to skip `n` number of initial headers
+- Configurable depth of headers to include
+- Customizable header for the table of contents
 
 **Please star the project if you like it!**
 
@@ -80,7 +82,31 @@ Output:
     - [License](#license)
     <!-- ToC end -->
 
+## Controlling depth of headers
+
+Using the `--depth` flag you can control how many labels of headers to include
+in the output. If the `--depth` is set to `1`, only level 1 headers are
+included. Set this value to `0` (default) to include any depth of headers.
+
+Command:
+
+    markdown-toc --depth 1 README.md
+
+Output:
+
+    <!-- ToC start -->
+    # Table of Contents
+
+    - [`markdown-toc` - Generate your Table of Contents](#`markdown-toc`---generate-your-table-of-contents)
+    - [Example usage](#example-usage)
+    - [License](#license)
+    <!-- ToC end -->
+
 ## Set a custom header
+
+By default we print a header like `# Table of Contents` above the table of
+contents. You can change the header to suit your project using the `--header`
+flag.
 
 Command:
 
@@ -98,6 +124,9 @@ Output:
     <!-- ToC end -->
 
 ## Render the ToC without a header
+
+By default we print a header like `# Table of Contents` above the table of
+contents. You can remove the header by providing `--no-header` to the command.
 
 Command:
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,11 @@ import (
 )
 
 var (
+	// depth indicates how many levels of headers should be included in the ToC.
+	//
+	// If 0, all headers are included.
+	depth int
+
 	// header is the string injected as a header for the table of contents.
 	header string
 
@@ -53,7 +58,7 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
-		t, err := toc.Build(d, header, skipHeaders, !noHeader)
+		t, err := toc.Build(d, header, depth, skipHeaders, !noHeader)
 		if err != nil {
 			return err
 		}
@@ -86,6 +91,7 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
+	RootCmd.Flags().IntVar(&depth, "depth", 0, "Depth of headers to include. Set to 0 for all headers")
 	RootCmd.Flags().StringVar(&header, "header", "# Table of Contents", "Text to use for the header for the ToC")
 	RootCmd.Flags().BoolVar(&noHeader, "no-header", false, "If this is set there will be no header for the ToC")
 	RootCmd.Flags().IntVar(&skipHeaders, "skip-headers", 0, "Number of headers to skip. Useful if you don't want e.g. the first header to be included in the ToC")

--- a/toc/build.go
+++ b/toc/build.go
@@ -15,7 +15,7 @@ var (
 )
 
 // Build is returning a ToC based on the input markdown.
-func Build(d []byte, header string, skipHeaders int, addHeader bool) ([]string, error) {
+func Build(d []byte, header string, depth, skipHeaders int, addHeader bool) ([]string, error) {
 	toc := []string{
 		"<!-- ToC start -->",
 	}
@@ -30,6 +30,10 @@ func Build(d []byte, header string, skipHeaders int, addHeader bool) ([]string, 
 		switch {
 		case rHashHeader.Match(s.Bytes()):
 			m := rHashHeader.FindStringSubmatch(s.Text())
+			if depth > 0 && len(m[1]) > depth {
+				continue
+			}
+
 			indent := len(m[1]) - 1
 			title := m[2]
 
@@ -49,6 +53,10 @@ func Build(d []byte, header string, skipHeaders int, addHeader bool) ([]string, 
 			toc = append(toc, fmt.Sprintf("- [%s](#%s)", previousLine, slugify(previousLine)))
 
 		case rUnderscoreHeader2.Match(s.Bytes()):
+			if depth > 0 && depth < 2 {
+				continue
+			}
+
 			if skipHeaders > 0 {
 				skipHeaders--
 				continue


### PR DESCRIPTION
The depth flag will make it possible for users to control how many levels of
headers should be included in the response.

Closes #1