### PR TITLE
Support repeated headers

### DIFF
--- a/toc/build_test.go
+++ b/toc/build_test.go
@@ -76,6 +76,27 @@ Some content
 				"<!-- ToC end -->",
 			},
 		},
+		"success - Repeated headers": {
+			data: []byte(`
+Header 1
+========
+Content
+
+# Header 1
+Some content
+`),
+			header:      "# Table of Contents",
+			depth:       0,
+			skipHeaders: 0,
+			addHeader:   true,
+			expectedToC: []string{
+				"<!-- ToC start -->",
+				"# Table of Contents\n",
+				"1. [Header 1](#header-1)",
+				"1. [Header 1](#header-1-1)",
+				"<!-- ToC end -->",
+			},
+		},
 		"skipping 3 headers": {
 			data: []byte(`
 Header 1


### PR DESCRIPTION
This commit will allow users to have headers with the exact same content twice.
The first link will be rendered as usual. The second link will have `-1`
appended.

Closes #6